### PR TITLE
feat(doc-infrastructure): add shared infrastructure library (Phase 1)

### DIFF
--- a/lib/core/output-utils.sh
+++ b/lib/core/output-utils.sh
@@ -71,6 +71,10 @@ dt_print_status() {
         "WARNING") echo -e "${DT_YELLOW}⚠️  $message${DT_NC}" ;;
         "SUCCESS") echo -e "${DT_GREEN}✅ $message${DT_NC}" ;;
         "INFO")    echo -e "${DT_BLUE}ℹ️  $message${DT_NC}" ;;
+        *)
+            echo -e "${DT_BLUE}ℹ️  [UNKNOWN:${msg_type}] $message${DT_NC}" >&2
+            return 1
+            ;;
     esac
 }
 

--- a/lib/core/output-utils.sh
+++ b/lib/core/output-utils.sh
@@ -71,10 +71,6 @@ dt_print_status() {
         "WARNING") echo -e "${DT_YELLOW}⚠️  $message${DT_NC}" ;;
         "SUCCESS") echo -e "${DT_GREEN}✅ $message${DT_NC}" ;;
         "INFO")    echo -e "${DT_BLUE}ℹ️  $message${DT_NC}" ;;
-        *)
-            echo -e "${DT_BLUE}ℹ️  [UNKNOWN:${msg_type}] $message${DT_NC}" >&2
-            return 1
-            ;;
     esac
 }
 

--- a/lib/core/output-utils.sh
+++ b/lib/core/output-utils.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+# Doc Infrastructure Shared Utilities
+# Provides common functions for dt-doc-gen and dt-doc-validate
+# Uses dt_* prefix to avoid conflicts with other dev-toolkit functions
+
+# ============================================================================
+# XDG BASE DIRECTORY COMPLIANCE
+# ============================================================================
+
+dt_get_xdg_config_home() {
+    echo "${XDG_CONFIG_HOME:-$HOME/.config}"
+}
+
+dt_get_xdg_data_home() {
+    echo "${XDG_DATA_HOME:-$HOME/.local/share}"
+}
+
+dt_get_config_dir() {
+    echo "$(dt_get_xdg_config_home)/dev-toolkit"
+}
+
+dt_get_data_dir() {
+    echo "$(dt_get_xdg_data_home)/dev-toolkit"
+}
+
+dt_get_config_file() {
+    echo "$(dt_get_config_dir)/config"
+}
+
+# ============================================================================
+# COLOR AND OUTPUT SETUP
+# ============================================================================
+
+# Color variables (set by dt_setup_colors)
+DT_RED=""
+DT_GREEN=""
+DT_YELLOW=""
+DT_BLUE=""
+DT_PURPLE=""
+DT_CYAN=""
+DT_BOLD=""
+DT_NC=""
+
+dt_setup_colors() {
+    if [[ -t 1 ]] && command -v tput >/dev/null 2>&1; then
+        DT_RED='\033[0;31m'
+        DT_GREEN='\033[0;32m'
+        DT_YELLOW='\033[1;33m'
+        DT_BLUE='\033[0;34m'
+        DT_PURPLE='\033[0;35m'
+        DT_CYAN='\033[0;36m'
+        DT_BOLD='\033[1m'
+        DT_NC='\033[0m'
+    else
+        DT_RED=''
+        DT_GREEN=''
+        DT_YELLOW=''
+        DT_BLUE=''
+        DT_PURPLE=''
+        DT_CYAN=''
+        DT_BOLD=''
+        DT_NC=''
+    fi
+}
+
+dt_print_status() {
+    local msg_type=$1
+    local message=$2
+    case $msg_type in
+        "ERROR")   echo -e "${DT_RED}❌ $message${DT_NC}" ;;
+        "WARNING") echo -e "${DT_YELLOW}⚠️  $message${DT_NC}" ;;
+        "SUCCESS") echo -e "${DT_GREEN}✅ $message${DT_NC}" ;;
+        "INFO")    echo -e "${DT_BLUE}ℹ️  $message${DT_NC}" ;;
+    esac
+}
+
+dt_print_debug() {
+    if [ "${DT_DEBUG:-false}" = "true" ]; then
+        echo -e "${DT_PURPLE}[DEBUG] $1${DT_NC}"
+    fi
+}
+
+dt_print_header() {
+    local title=$1
+    echo -e "${DT_BOLD}${DT_CYAN}$title${DT_NC}"
+    echo -e "${DT_CYAN}$(printf '═%.0s' $(seq 1 ${#title}))${DT_NC}"
+}
+
+dt_show_version() {
+    local version_file="${TOOLKIT_ROOT:-$(dirname "${BASH_SOURCE[0]}")/../..}/VERSION"
+    if [ -f "$version_file" ]; then
+        cat "$version_file"
+    else
+        echo "unknown"
+    fi
+}
+
+# ============================================================================
+# DETECTION FUNCTIONS
+# ============================================================================
+
+dt_detect_dev_infra() {
+    # 1. Environment variable (highest priority)
+    if [ -n "${DEV_INFRA_PATH:-}" ] && [ -d "$DEV_INFRA_PATH" ]; then
+        echo "$DEV_INFRA_PATH"
+        return 0
+    fi
+    
+    # 2. Sibling directory (common development setup)
+    local script_dir
+    if [ -n "${BASH_SOURCE[0]:-}" ]; then
+        script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    else
+        script_dir="$(pwd)"
+    fi
+    
+    # Look for dev-infra as sibling to dev-toolkit
+    local toolkit_root="${script_dir%/lib/core}"
+    local sibling_path="${toolkit_root%/*}/dev-infra"
+    if [ -d "$sibling_path" ]; then
+        echo "$sibling_path"
+        return 0
+    fi
+    
+    # 3. Common default locations
+    local default_paths=(
+        "$HOME/Projects/dev-infra"
+        "$HOME/.dev-infra"
+    )
+    
+    for path in "${default_paths[@]}"; do
+        if [ -d "$path" ]; then
+            echo "$path"
+            return 0
+        fi
+    done
+    
+    # Not found
+    return 1
+}
+
+dt_detect_project_structure() {
+    local current_dir="${1:-.}"
+    
+    # Priority: admin/ first for backward compatibility
+    if [ -d "$current_dir/admin/explorations" ] || \
+       [ -d "$current_dir/admin/research" ] || \
+       [ -d "$current_dir/admin/decisions" ] || \
+       [ -d "$current_dir/admin/planning" ]; then
+        echo "admin"
+        return 0
+    fi
+    
+    # Then check docs/maintainers/ (newer structure)
+    if [ -d "$current_dir/docs/maintainers/explorations" ] || \
+       [ -d "$current_dir/docs/maintainers/research" ] || \
+       [ -d "$current_dir/docs/maintainers/decisions" ] || \
+       [ -d "$current_dir/docs/maintainers/planning" ]; then
+        echo "docs/maintainers"
+        return 0
+    fi
+    
+    echo "unknown"
+    return 0
+}
+
+dt_get_docs_root() {
+    local project_dir="${1:-.}"
+    local structure
+    structure=$(dt_detect_project_structure "$project_dir")
+    
+    case "$structure" in
+        "admin")
+            echo "$project_dir/admin"
+            ;;
+        "docs/maintainers")
+            echo "$project_dir/docs/maintainers"
+            ;;
+        *)
+            echo ""
+            return 1
+            ;;
+    esac
+}

--- a/tests/unit/core/test-output-utils.bats
+++ b/tests/unit/core/test-output-utils.bats
@@ -1,0 +1,268 @@
+#!/usr/bin/env bats
+
+# Tests for output-utils.sh shared library
+
+load '../../helpers/setup'
+load '../../helpers/assertions'
+
+setup() {
+    source "$PROJECT_ROOT/lib/core/output-utils.sh"
+}
+
+# ============================================================================
+# XDG Helper Tests
+# ============================================================================
+
+@test "dt_get_xdg_config_home: returns XDG_CONFIG_HOME if set" {
+    export XDG_CONFIG_HOME="/custom/config"
+    run dt_get_xdg_config_home
+    [ "$status" -eq 0 ]
+    [ "$output" = "/custom/config" ]
+}
+
+@test "dt_get_xdg_config_home: returns ~/.config if XDG_CONFIG_HOME not set" {
+    unset XDG_CONFIG_HOME
+    run dt_get_xdg_config_home
+    [ "$status" -eq 0 ]
+    [ "$output" = "$HOME/.config" ]
+}
+
+@test "dt_get_xdg_data_home: returns XDG_DATA_HOME if set" {
+    export XDG_DATA_HOME="/custom/data"
+    run dt_get_xdg_data_home
+    [ "$status" -eq 0 ]
+    [ "$output" = "/custom/data" ]
+}
+
+@test "dt_get_xdg_data_home: returns ~/.local/share if XDG_DATA_HOME not set" {
+    unset XDG_DATA_HOME
+    run dt_get_xdg_data_home
+    [ "$status" -eq 0 ]
+    [ "$output" = "$HOME/.local/share" ]
+}
+
+@test "dt_get_config_dir: returns dev-toolkit config directory" {
+    unset XDG_CONFIG_HOME
+    run dt_get_config_dir
+    [ "$status" -eq 0 ]
+    [ "$output" = "$HOME/.config/dev-toolkit" ]
+}
+
+@test "dt_get_data_dir: returns dev-toolkit data directory" {
+    unset XDG_DATA_HOME
+    run dt_get_data_dir
+    [ "$status" -eq 0 ]
+    [ "$output" = "$HOME/.local/share/dev-toolkit" ]
+}
+
+@test "dt_get_config_file: returns config file path" {
+    unset XDG_CONFIG_HOME
+    run dt_get_config_file
+    [ "$status" -eq 0 ]
+    [ "$output" = "$HOME/.config/dev-toolkit/config" ]
+}
+
+# ============================================================================
+# Color Setup Tests
+# ============================================================================
+
+@test "dt_setup_colors: sets color variables" {
+    # Reset any existing colors
+    DT_RED=""
+    DT_GREEN=""
+    dt_setup_colors
+    # Colors should be set (either with codes or empty for non-TTY)
+    [ -n "${DT_NC+x}" ]  # Variable exists (may be empty)
+}
+
+# ============================================================================
+# Print Status Tests
+# ============================================================================
+
+@test "dt_print_status: ERROR includes error emoji and message" {
+    dt_setup_colors
+    run dt_print_status "ERROR" "Test error message"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "❌" ]]
+    [[ "$output" =~ "Test error message" ]]
+}
+
+@test "dt_print_status: WARNING includes warning emoji and message" {
+    dt_setup_colors
+    run dt_print_status "WARNING" "Test warning"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "⚠️" ]]
+    [[ "$output" =~ "Test warning" ]]
+}
+
+@test "dt_print_status: SUCCESS includes success emoji and message" {
+    dt_setup_colors
+    run dt_print_status "SUCCESS" "Test success"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "✅" ]]
+    [[ "$output" =~ "Test success" ]]
+}
+
+@test "dt_print_status: INFO includes info emoji and message" {
+    dt_setup_colors
+    run dt_print_status "INFO" "Test info"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "ℹ️" ]]
+    [[ "$output" =~ "Test info" ]]
+}
+
+# ============================================================================
+# Debug Output Tests
+# ============================================================================
+
+@test "dt_print_debug: outputs when DT_DEBUG=true" {
+    export DT_DEBUG=true
+    dt_setup_colors
+    run dt_print_debug "Debug message"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Debug message" ]]
+}
+
+@test "dt_print_debug: silent when DT_DEBUG not set" {
+    unset DT_DEBUG
+    dt_setup_colors
+    run dt_print_debug "Debug message"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# ============================================================================
+# Print Header Tests
+# ============================================================================
+
+@test "dt_print_header: outputs header with title" {
+    dt_setup_colors
+    run dt_print_header "Test Header"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Test Header" ]]
+}
+
+# ============================================================================
+# dev-infra Detection Tests
+# ============================================================================
+
+@test "dt_detect_dev_infra: returns path when DEV_INFRA_PATH set" {
+    local test_dir=$(mktemp -d)
+    mkdir -p "$test_dir"
+    export DEV_INFRA_PATH="$test_dir"
+    run dt_detect_dev_infra
+    [ "$status" -eq 0 ]
+    [ "$output" = "$test_dir" ]
+    rm -rf "$test_dir"
+    unset DEV_INFRA_PATH
+}
+
+@test "dt_detect_dev_infra: returns error when not found" {
+    unset DEV_INFRA_PATH
+    # Create temp dir with no dev-infra sibling and not in Projects
+    local test_dir=$(mktemp -d)
+    # Temporarily change HOME to isolate from real dev-infra
+    local old_home="$HOME"
+    export HOME="$test_dir"
+    cd "$test_dir"
+    run dt_detect_dev_infra
+    [ "$status" -eq 1 ]
+    export HOME="$old_home"
+    rm -rf "$test_dir"
+}
+
+# ============================================================================
+# Project Structure Detection Tests
+# ============================================================================
+
+@test "dt_detect_project_structure: returns 'admin' when admin/ exists" {
+    local test_dir=$(mktemp -d)
+    mkdir -p "$test_dir/admin/explorations"
+    run dt_detect_project_structure "$test_dir"
+    [ "$status" -eq 0 ]
+    [ "$output" = "admin" ]
+    rm -rf "$test_dir"
+}
+
+@test "dt_detect_project_structure: returns 'docs/maintainers' when that exists" {
+    local test_dir=$(mktemp -d)
+    mkdir -p "$test_dir/docs/maintainers/explorations"
+    run dt_detect_project_structure "$test_dir"
+    [ "$status" -eq 0 ]
+    [ "$output" = "docs/maintainers" ]
+    rm -rf "$test_dir"
+}
+
+@test "dt_detect_project_structure: prioritizes 'admin' over 'docs/maintainers'" {
+    local test_dir=$(mktemp -d)
+    mkdir -p "$test_dir/admin/explorations"
+    mkdir -p "$test_dir/docs/maintainers/explorations"
+    run dt_detect_project_structure "$test_dir"
+    [ "$status" -eq 0 ]
+    [ "$output" = "admin" ]
+    rm -rf "$test_dir"
+}
+
+@test "dt_detect_project_structure: returns 'unknown' when neither exists" {
+    local test_dir=$(mktemp -d)
+    run dt_detect_project_structure "$test_dir"
+    [ "$status" -eq 0 ]
+    [ "$output" = "unknown" ]
+    rm -rf "$test_dir"
+}
+
+@test "dt_get_docs_root: returns 'admin' path for admin structure" {
+    local test_dir=$(mktemp -d)
+    mkdir -p "$test_dir/admin/explorations"
+    run dt_get_docs_root "$test_dir"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$test_dir/admin" ]
+    rm -rf "$test_dir"
+}
+
+@test "dt_get_docs_root: returns 'docs/maintainers' path for that structure" {
+    local test_dir=$(mktemp -d)
+    mkdir -p "$test_dir/docs/maintainers/explorations"
+    run dt_get_docs_root "$test_dir"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$test_dir/docs/maintainers" ]
+    rm -rf "$test_dir"
+}
+
+# ============================================================================
+# Integration Tests
+# ============================================================================
+
+@test "output-utils.sh: sources without errors" {
+    run source "$PROJECT_ROOT/lib/core/output-utils.sh"
+    [ "$status" -eq 0 ]
+}
+
+@test "output-utils.sh: all dt_* functions are defined" {
+    source "$PROJECT_ROOT/lib/core/output-utils.sh"
+    
+    # XDG helpers
+    [ "$(type -t dt_get_xdg_config_home)" = "function" ]
+    [ "$(type -t dt_get_xdg_data_home)" = "function" ]
+    [ "$(type -t dt_get_config_dir)" = "function" ]
+    [ "$(type -t dt_get_data_dir)" = "function" ]
+    [ "$(type -t dt_get_config_file)" = "function" ]
+    
+    # Output functions
+    [ "$(type -t dt_setup_colors)" = "function" ]
+    [ "$(type -t dt_print_status)" = "function" ]
+    [ "$(type -t dt_print_debug)" = "function" ]
+    [ "$(type -t dt_print_header)" = "function" ]
+    [ "$(type -t dt_show_version)" = "function" ]
+    
+    # Detection functions
+    [ "$(type -t dt_detect_dev_infra)" = "function" ]
+    [ "$(type -t dt_detect_project_structure)" = "function" ]
+    [ "$(type -t dt_get_docs_root)" = "function" ]
+}
+
+@test "dt_show_version: outputs version from VERSION file" {
+    run dt_show_version
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]
+}

--- a/tests/unit/core/test-output-utils.bats
+++ b/tests/unit/core/test-output-utils.bats
@@ -111,6 +111,14 @@ setup() {
     [[ "$output" =~ "Test info" ]]
 }
 
+@test "dt_print_status: unknown type returns error and shows UNKNOWN prefix" {
+    dt_setup_colors
+    run dt_print_status "INVALID" "Test message"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "UNKNOWN:INVALID" ]]
+    [[ "$output" =~ "Test message" ]]
+}
+
 # ============================================================================
 # Debug Output Tests
 # ============================================================================

--- a/tests/unit/core/test-output-utils.bats
+++ b/tests/unit/core/test-output-utils.bats
@@ -111,14 +111,6 @@ setup() {
     [[ "$output" =~ "Test info" ]]
 }
 
-@test "dt_print_status: unknown type returns error and shows UNKNOWN prefix" {
-    dt_setup_colors
-    run dt_print_status "INVALID" "Test message"
-    [ "$status" -eq 1 ]
-    [[ "$output" =~ "UNKNOWN:INVALID" ]]
-    [[ "$output" =~ "Test message" ]]
-}
-
 # ============================================================================
 # Debug Output Tests
 # ============================================================================


### PR DESCRIPTION
## Phase 1: Shared Infrastructure (Code Only)

**Status:** ✅ Complete  
**Completed:** 2026-01-21

---

## Summary

Creates the shared infrastructure library (`lib/core/output-utils.sh`) for the doc-infrastructure feature. This library provides common functions with `dt_*` prefix that will be used by both `dt-doc-gen` and `dt-doc-validate`.

---

## Changes

### New Files

| File | Lines | Description |
|------|-------|-------------|
| `lib/core/output-utils.sh` | 184 | Shared library with 13 functions |
| `tests/unit/core/test-output-utils.bats` | 268 | Unit tests (26 tests) |

### Functions Added

| Category | Functions |
|----------|-----------|
| **XDG Helpers** | `dt_get_xdg_config_home`, `dt_get_xdg_data_home`, `dt_get_config_dir`, `dt_get_data_dir`, `dt_get_config_file` |
| **Output** | `dt_setup_colors`, `dt_print_status`, `dt_print_debug`, `dt_print_header`, `dt_show_version` |
| **Detection** | `dt_detect_dev_infra`, `dt_detect_project_structure`, `dt_get_docs_root` |

---

## Technical Details

### XDG Base Directory Compliance

Follows XDG Base Directory Specification:
- Config: `${XDG_CONFIG_HOME:-~/.config}/dev-toolkit`
- Data: `${XDG_DATA_HOME:-~/.local/share}/dev-toolkit`

### Project Structure Detection

Supports backward compatibility:
- **admin/** - Legacy structure (detected first)
- **docs/maintainers/** - Newer structure

### dev-infra Detection

Layered discovery:
1. `DEV_INFRA_PATH` environment variable
2. Sibling directory to dev-toolkit
3. Default paths (`~/Projects/dev-infra`, `~/.dev-infra`)

---

## Testing

- [x] All tests passing (26 tests)
- [x] All 13 `dt_*` functions tested
- [x] TDD approach followed
- [x] No regressions

---

## Related

- **ADR-005:** Shared Infrastructure decision
- **Phase Plan:** `admin/planning/features/doc-infrastructure/phase-1.md` (in feature branch)

## Summary by Sourcery

Introduce a shared Bash utilities library for documentation tooling and cover it with unit tests.

New Features:
- Add output-utils.sh shared Bash library providing XDG config/data helpers, colored/status output, and project/dev-infra detection functions for doc-related tools.

Tests:
- Add Bats unit tests and integration checks covering all shared output-utils functions and behaviors, including XDG paths, color setup, status/debug printing, version output, and project/dev-infra detection.