### PR TITLE
fix: Documentation cleanup (pr33-batch-low-low-01)

### DIFF
--- a/admin/planning/features/dt-workflow/fix/pr33/batch-low-low-01.md
+++ b/admin/planning/features/dt-workflow/fix/pr33/batch-low-low-01.md
@@ -4,7 +4,9 @@
 **Batch:** low-low-01  
 **Priority:** 🟢 LOW  
 **Effort:** 🟢 LOW  
-**Status:** 🔴 Not Started  
+**Status:** ✅ Complete  
+**Completed:** 2026-01-27  
+**PR:** #35  
 **Created:** 2026-01-27  
 **Issues:** 3 issues
 

--- a/admin/planning/features/dt-workflow/phase-2-template-changes.md
+++ b/admin/planning/features/dt-workflow/phase-2-template-changes.md
@@ -1,6 +1,6 @@
 # Phase 2 Template Enhancement Requirements
 
-**Purpose:** Document template changes needed in dev-infra for Phase 2, Tasks 1-3  
+**Purpose:** Document template changes needed in dev-infra for Phase 2, Tasks 1-2 (Exploration and Research templates)  
 **Status:** 🟡 Pending (dev-infra changes required)  
 **Created:** 2026-01-26  
 **Related:** ADR-006, FR-24, FR-26, NFR-7
@@ -215,7 +215,7 @@ After enhancement, template should produce output like:
 3. <!-- AI: Third key insight -->
 ```
 
-### Validation
+### Research Template Validation
 
 **Test File:** `dev-toolkit/tests/unit/test-template-enhancement.bats`
 
@@ -232,7 +232,7 @@ Tests validate:
 
 ---
 
-## Validation
+## Exploration Template Validation
 
 **Test File:** `dev-toolkit/tests/unit/test-template-enhancement.bats`
 

--- a/tests/unit/test-template-enhancement.bats
+++ b/tests/unit/test-template-enhancement.bats
@@ -443,6 +443,10 @@ teardown() {
     }
 }
 
+# Note: This test validates that the templating system *can* render template
+# variable documentation (proving templating capabilities), not that it *must*
+# appear in final user-facing ADRs. Template variables documentation is already
+# properly validated via TEMPLATE-VARIABLES.md in test-template-variables-doc.bats.
 @test "decision template includes template variable documentation" {
     skip_if_no_templates
     


### PR DESCRIPTION
## Fix Batch: pr33-batch-low-low-01

Fixes 3 documentation clarity issues from PR #33 Sourcery review.

---

## Issues Fixed

- **PR33-#1:** Purpose line mismatch in phase-2-template-changes.md (🟢 LOW, 🟢 LOW)
- **PR33-#2:** Validation section heading ambiguity (🟢 LOW, 🟢 LOW)
- **PR33-Overall-#2:** Template variable heading in ADR test (🟢 LOW, 🟢 LOW)

---

## Changes

### PR33-#1: Fix Purpose Line

**File:** `admin/planning/features/dt-workflow/phase-2-template-changes.md`

Updated purpose line from "Tasks 1-3" to "Tasks 1-2" to match actual document content.

### PR33-#2: Add Template Names to Validation Headings

**File:** `admin/planning/features/dt-workflow/phase-2-template-changes.md`

- Renamed "## Validation" to "## Exploration Template Validation"
- Renamed "### Validation" to "### Research Template Validation"

Makes it clear which template each validation section applies to.

### PR33-Overall-#2: Add Clarifying Comment to Test

**File:** `tests/unit/test-template-enhancement.bats`

Added comment explaining that the test validates templating capabilities, not that template variable documentation must appear in final user-facing ADRs.

---

## Testing

- [x] Documentation renders correctly (no broken links)
- [x] Document structure is clearer after changes
- [x] All tests pass
- [x] No regressions introduced

---

## Related

- **Fix Plan:** `admin/planning/features/dt-workflow/fix/pr33/batch-low-low-01.md`
- **Sourcery Review:** `admin/feedback/sourcery/pr33.md`
- **Original PR:** #33

## Summary by Sourcery

Clarify documentation around Phase 2 template enhancements and their associated tests.

Documentation:
- Update the Phase 2 template enhancement requirements purpose line to accurately describe the covered tasks and templates.
- Disambiguate validation section headings by explicitly naming the Exploration and Research templates they apply to.

Tests:
- Add a clarifying comment to the template enhancement test to explain it validates templating capability, not user-facing ADR content.